### PR TITLE
Remove `!important` from grid-template-columns

### DIFF
--- a/src/tiddlywiki-codemirror-6/tiddlers/styles/styles.tid
+++ b/src/tiddlywiki-codemirror-6/tiddlers/styles/styles.tid
@@ -453,7 +453,7 @@ input.btc-search-input:focus {
 
 <!-- https://github.com/Jermolene/TiddlyWiki5/pull/7787 -->
 .tc-tiddler-preview {
-	grid-template-columns: repeat(2, minmax(0px, 1fr)) !important;
+	grid-template-columns: repeat(2, minmax(0px, 1fr));
 }
 
 <!-- NOTE: if include emoji, emoji will broken use font-bold, emoji was split two chars because of dymamic matchedtext -->


### PR DESCRIPTION
Remove `!important` from grid-template-columns
https://talk.tiddlywiki.org/t/yar-yet-another-resizer/13060/23?

We've found out, that this `!important` breaks the resizer widget when used with your CodeMirror 6 plugin and we think it's not necessary anymore to use `!important` here